### PR TITLE
Remove merge conflict cruft

### DIFF
--- a/blog/requirements.pip
+++ b/blog/requirements.pip
@@ -1,9 +1,6 @@
 Django==1.5.1
 MySQL-python==1.2.4
-<<<<<<< HEAD
-=======
 South==0.8.2
->>>>>>> part3
 argparse==1.2.1
 djangorestframework==2.3.6
 wsgiref==0.1.2


### PR DESCRIPTION
Some leftovers from a merge were in the requirements.pip
file, meaning trying to install from the requirements file
would throw an error.
